### PR TITLE
Switch to DeepSeek R1 model on OpenRouter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## Summary
- remove browser key helper and use environment variable directly
- call OpenRouter with `deepseek/deepseek-r1:free` model and required headers
- ignore `node_modules` in git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b3a3964c832dbeede6e48e402408