### PR TITLE
Use GPT-OSS model for AI recommendations

### DIFF
--- a/src/app/ai/page.js
+++ b/src/app/ai/page.js
@@ -141,7 +141,7 @@ export default function Page() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: "deepseek/deepseek-r1:free",
+          model: "openai/gpt-oss-20b:free",
           messages: [
             {
               role: "user",


### PR DESCRIPTION
## Summary
- switch AI Picks to use `openai/gpt-oss-20b:free` model via OpenRouter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b8aba554832da07af2b667aae7ba